### PR TITLE
Add timezone option to Octokit constructor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,10 @@ export class Octokit {
       requestDefaults.mediaType.previews = options.previews;
     }
 
+    if (options.timeZone) {
+      requestDefaults.headers["time-zone"] = options.timeZone;
+    }
+
     if (options.auth) {
       if (typeof options.auth === "string") {
         requestDefaults.headers.authorization = withAuthorizationPrefix(

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ import { Octokit } from ".";
 export type OctokitOptions = {
   auth?: string | AutenticationHook;
   request?: OctokitRequestOptions;
+  timeZone?: string;
   [option: string]: any;
 };
 

--- a/test/defaults.test.ts
+++ b/test/defaults.test.ts
@@ -63,6 +63,33 @@ describe("Octokit.defaults", () => {
     });
   });
 
+  it("Octokit.defaults({timeZone})", () => {
+    const mock = fetchMock.sandbox().getOnce(
+      "https://api.github.com/",
+      { ok: true },
+      {
+        headers: {
+          accept: "application/vnd.github.v3+json",
+          "user-agent": userAgent,
+          "time-zone": "Europe/Amsterdam"
+        }
+      }
+    );
+
+    const OctokitWithDefaults = Octokit.defaults({
+      timeZone: "Europe/Amsterdam",
+      request: {
+        fetch: mock
+      }
+    });
+
+    const octokit = new OctokitWithDefaults();
+
+    return octokit.request("GET /").then(response => {
+      expect(response.data).toStrictEqual({ ok: true });
+    });
+  });
+
   it("Octokit.defaults({auth})", async () => {
     const mock = fetchMock.sandbox().getOnce(
       "https://api.github.com/app",

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -75,6 +75,31 @@ describe("octokit.request()", () => {
     });
   });
 
+  it("custom time zone", () => {
+    const mock = fetchMock.sandbox().getOnce(
+      "https://api.github.com/",
+      { ok: true },
+      {
+        headers: {
+          accept: "application/vnd.github.v3+json",
+          "user-agent": userAgent,
+          "time-zone": "Europe/Amsterdam"
+        }
+      }
+    );
+
+    const octokit = new Octokit({
+      timeZone: "Europe/Amsterdam",
+      request: {
+        fetch: mock
+      }
+    });
+
+    return octokit.request("GET /").then(response => {
+      expect(response.data).toStrictEqual({ ok: true });
+    });
+  });
+
   it("previews", async () => {
     const mock = fetchMock
       .sandbox()


### PR DESCRIPTION
This adds a timeZone option to the Octokit constructor. The value provided is set as the time-zone header in the client defaults, so all requests made with that octokit instance will have that time-zone header.

I added test cases for this in `defaults.test.ts` and `request.test.ts`.

This is pretty similar to https://github.com/octokit/rest.js/pull/1498, but if anything in this PR isn't as idiomatic to this repo I'm happy to make changes!