### PR TITLE
ci: widen branch pattern to cover scoped packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-      - "greenkeeper/*"
+      - "greenkeeper/**"
   pull_request:
     types: [opened, synchronize]
 


### PR DESCRIPTION
Packages that are scoped - maybe with an organization name - will not match the current pattern and the workflow will not be triggered.