### PR TITLE
fix: Fixes type-widening bug when handling plugins.

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ See [before-after-hook](https://github.com/gr2m/before-after-hook#readme) for 
 
 ## Plugins
 
-Octokit’s functionality can be extended using plugins. THe `Octokit.plugin()` method accepts a function or an array of functions and returns a new constructor.
+Octokit’s functionality can be extended using plugins. The `Octokit.plugin()` method accepts a plugin (or many) and returns a new constructor.
 
 A plugin is a function which gets two arguments:
 
@@ -353,10 +353,10 @@ In order to extend `octokit`'s API, the plugin must return an object with the ne
 
 ```js
 // index.js
-const MyOctokit = require("@octokit/core").plugin([
+const MyOctokit = require("@octokit/core").plugin(
   require("./lib/my-plugin"),
   require("octokit-plugin-example")
-]);
+);
 
 const octokit = new MyOctokit({ greeting: "Moin moin" });
 octokit.helloWorld(); // logs "Moin moin, world!"
@@ -388,11 +388,11 @@ You can build your own Octokit class with preset default options and plugins. In
 
 ```js
 const MyActionOctokit = require("@octokit/core")
-  .plugin([
+  .plugin(
     require("@octokit/plugin-paginate"),
     require("@octokit/plugin-throttle"),
     require("@octokit/plugin-retry")
-  ])
+  )
   .defaults({
     authStrategy: require("@octokit/auth-action"),
     userAgent: `my-octokit-action/v1.2.3`

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,9 +59,9 @@ export class Octokit {
         [
           "Passing an array of plugins to octokit.plugin() has been deprecated and support will be removed with v18.",
           "Instead of:",
-          "  octokit.plugin([plugin1, plugin2, ...])",
+          "  Octokit.plugin([plugin1, plugin2, ...])",
           "Use:",
-          "  octokit.plugin(plugin1, plugin2, ...)",
+          "  Octokit.plugin(plugin1, plugin2, ...)",
         ].join("\n")
       );
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ export class Octokit {
   static plugins: OctokitPlugin[] = [];
   /**
    * Attach a plugin (or many) to your Octokit instance.
-   * 
+   *
    * @example
    * const API = Octokit.plugin(plugin1, plugin2, plugin3, ...)
    */
@@ -55,21 +55,20 @@ export class Octokit {
     T2 extends OctokitPlugin[]
   >(this: S, p1: T1, ...p2: T2) {
     const currentPlugins = this.plugins;
-      let newPlugins: (OctokitPlugin | undefined)[] = [
-        ...(p1 instanceof Array ? p1 as OctokitPlugin[] : [p1 as OctokitPlugin]), 
-        ...p2
-      ]
+    let newPlugins: (OctokitPlugin | undefined)[] = [
+      ...(p1 instanceof Array
+        ? (p1 as OctokitPlugin[])
+        : [p1 as OctokitPlugin]),
+      ...p2
+    ];
     const NewOctokit = class extends this {
       static plugins = currentPlugins.concat(
         newPlugins.filter(plugin => !currentPlugins.includes(plugin))
       );
     };
 
-    return NewOctokit as typeof NewOctokit
-      & Constructor<UnionToIntersection<
-          ReturnTypeOf<T1>
-        & ReturnTypeOf<T2> 
-      >>;
+    return NewOctokit as typeof NewOctokit &
+      Constructor<UnionToIntersection<ReturnTypeOf<T1> & ReturnTypeOf<T2>>>;
   }
 
   constructor(options: OctokitOptions = {}) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ export class Octokit {
     if (p1 instanceof Array) {
       console.warn(
         [
-          "Passing an array of plugins to octokit.plugin() has been deprecated and support will be removed with v18.",
+          "Passing an array of plugins to Octokit.plugin() has been deprecated.",
           "Instead of:",
           "  Octokit.plugin([plugin1, plugin2, ...])",
           "Use:",

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,12 +44,18 @@ export class Octokit {
   static plugins: OctokitPlugin[] = [];
   static plugin<
     S extends Constructor<any> & { plugins: any[] },
-    T extends OctokitPlugin | OctokitPlugin[]
-  >(this: S, pluginOrPlugins: T) {
+    T1 extends OctokitPlugin,
+    T2 extends OctokitPlugin,
+    T3 extends OctokitPlugin,
+    T4 extends OctokitPlugin
+  >(this: S, p1: T1, p2?: T2, p3?: T3, p4?: T4) {
     const currentPlugins = this.plugins;
-    const newPlugins = Array.isArray(pluginOrPlugins)
-      ? pluginOrPlugins
-      : [pluginOrPlugins];
+    // TODO: Warn array method is deprecated and will be removed soon.
+    // const newPlugins = Array.isArray(pluginOrPlugins)
+    //   ? pluginOrPlugins
+    //   : [pluginOrPlugins];
+
+    let newPlugins: (OctokitPlugin | undefined)[] = [p1, p2, p3, p4]
 
     const NewOctokit = class extends this {
       static plugins = currentPlugins.concat(
@@ -57,7 +63,12 @@ export class Octokit {
       );
     };
 
-    return NewOctokit as typeof NewOctokit & Constructor<ReturnTypeOf<T>>;
+    // TODO: Do we need to wrap ReturnTypeOf with UnionToIntersection?
+    return NewOctokit as typeof NewOctokit
+      & Constructor<ReturnTypeOf<T1>>
+      & Constructor<ReturnTypeOf<T2>>
+      & Constructor<ReturnTypeOf<T3>>
+      & Constructor<ReturnTypeOf<T4>>;
   }
 
   constructor(options: OctokitOptions = {}) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {
   OctokitPlugin,
   RequestParameters,
   ReturnTypeOf,
-  UnionToIntersection
+  UnionToIntersection,
 } from "./types";
 import { VERSION } from "./version";
 
@@ -61,7 +61,7 @@ export class Octokit {
           "Instead of:",
           "  octokit.plugin([plugin1, plugin2, ...])",
           "Use:",
-          "  octokit.plugin(plugin1, plugin2, ...)"
+          "  octokit.plugin(plugin1, plugin2, ...)",
         ].join("\n")
       );
     }
@@ -70,7 +70,7 @@ export class Octokit {
       ...(p1 instanceof Array
         ? (p1 as OctokitPlugin[])
         : [p1 as OctokitPlugin]),
-      ...p2
+      ...p2,
     ];
     const NewOctokit = class extends this {
       static plugins = currentPlugins.concat(

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,8 @@ import {
   OctokitOptions,
   OctokitPlugin,
   RequestParameters,
-  ReturnTypeOf
+  ReturnTypeOf,
+  UnionToIntersection
 } from "./types";
 import { VERSION } from "./version";
 
@@ -44,18 +45,23 @@ export class Octokit {
   static plugins: OctokitPlugin[] = [];
   static plugin<
     S extends Constructor<any> & { plugins: any[] },
-    T1 extends OctokitPlugin,
+    T1 extends OctokitPlugin | OctokitPlugin[],
     T2 extends OctokitPlugin,
     T3 extends OctokitPlugin,
-    T4 extends OctokitPlugin
-  >(this: S, p1: T1, p2?: T2, p3?: T3, p4?: T4) {
+    T4 extends OctokitPlugin,
+    T5 extends OctokitPlugin,
+    T6 extends OctokitPlugin,
+    T7 extends OctokitPlugin,
+    T8 extends OctokitPlugin,
+    T9 extends OctokitPlugin[]
+  >(this: S, p1: T1, p2?: T2, p3?: T3, p4?: T4, p5?: T5, p6?: T6, p7?: T7, p8?: T8, ...p9: T9) {
     const currentPlugins = this.plugins;
-    // TODO: Warn array method is deprecated and will be removed soon.
-    // const newPlugins = Array.isArray(pluginOrPlugins)
-    //   ? pluginOrPlugins
-    //   : [pluginOrPlugins];
-
-    let newPlugins: (OctokitPlugin | undefined)[] = [p1, p2, p3, p4]
+      let newPlugins: (OctokitPlugin | undefined)[] = [
+        ...(p1 instanceof Array ? p1 as OctokitPlugin[] : [p1 as OctokitPlugin]), 
+        p2, p3, p4, p5, p6, p7, p8, ...p9
+      ].map(v => {
+        return typeof v === 'function' ? v : undefined
+      })
 
     const NewOctokit = class extends this {
       static plugins = currentPlugins.concat(
@@ -63,12 +69,18 @@ export class Octokit {
       );
     };
 
-    // TODO: Do we need to wrap ReturnTypeOf with UnionToIntersection?
     return NewOctokit as typeof NewOctokit
-      & Constructor<ReturnTypeOf<T1>>
-      & Constructor<ReturnTypeOf<T2>>
-      & Constructor<ReturnTypeOf<T3>>
-      & Constructor<ReturnTypeOf<T4>>;
+      & Constructor<UnionToIntersection<
+          ReturnTypeOf<T1>
+        & ReturnTypeOf<T2> 
+        & ReturnTypeOf<T3> 
+        & ReturnTypeOf<T4> 
+        & ReturnTypeOf<T5> 
+        & ReturnTypeOf<T6> 
+        & ReturnTypeOf<T7> 
+        & ReturnTypeOf<T8> 
+        & ReturnTypeOf<T9>
+      >>;
   }
 
   constructor(options: OctokitOptions = {}) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,26 +43,22 @@ export class Octokit {
   }
 
   static plugins: OctokitPlugin[] = [];
+  /**
+   * Attach a plugin (or many) to your Octokit instance.
+   * 
+   * @example
+   * const API = Octokit.plugin(plugin1, plugin2, plugin3, ...)
+   */
   static plugin<
     S extends Constructor<any> & { plugins: any[] },
     T1 extends OctokitPlugin | OctokitPlugin[],
-    T2 extends OctokitPlugin,
-    T3 extends OctokitPlugin,
-    T4 extends OctokitPlugin,
-    T5 extends OctokitPlugin,
-    T6 extends OctokitPlugin,
-    T7 extends OctokitPlugin,
-    T8 extends OctokitPlugin,
-    T9 extends OctokitPlugin[]
-  >(this: S, p1: T1, p2?: T2, p3?: T3, p4?: T4, p5?: T5, p6?: T6, p7?: T7, p8?: T8, ...p9: T9) {
+    T2 extends OctokitPlugin[]
+  >(this: S, p1: T1, ...p2: T2) {
     const currentPlugins = this.plugins;
       let newPlugins: (OctokitPlugin | undefined)[] = [
         ...(p1 instanceof Array ? p1 as OctokitPlugin[] : [p1 as OctokitPlugin]), 
-        p2, p3, p4, p5, p6, p7, p8, ...p9
-      ].map(v => {
-        return typeof v === 'function' ? v : undefined
-      })
-
+        ...p2
+      ]
     const NewOctokit = class extends this {
       static plugins = currentPlugins.concat(
         newPlugins.filter(plugin => !currentPlugins.includes(plugin))
@@ -73,13 +69,6 @@ export class Octokit {
       & Constructor<UnionToIntersection<
           ReturnTypeOf<T1>
         & ReturnTypeOf<T2> 
-        & ReturnTypeOf<T3> 
-        & ReturnTypeOf<T4> 
-        & ReturnTypeOf<T5> 
-        & ReturnTypeOf<T6> 
-        & ReturnTypeOf<T7> 
-        & ReturnTypeOf<T8> 
-        & ReturnTypeOf<T9>
       >>;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,17 @@ export class Octokit {
     T1 extends OctokitPlugin | OctokitPlugin[],
     T2 extends OctokitPlugin[]
   >(this: S, p1: T1, ...p2: T2) {
+    if (p1 instanceof Array) {
+      console.warn(
+        [
+          "Passing an array of plugins to octokit.plugin() has been deprecated and support will be removed with v18.",
+          "Instead of:",
+          "  octokit.plugin([plugin1, plugin2, ...])",
+          "Use:",
+          "  octokit.plugin(plugin1, plugin2, ...)"
+        ].join("\n")
+      );
+    }
     const currentPlugins = this.plugins;
     let newPlugins: (OctokitPlugin | undefined)[] = [
       ...(p1 instanceof Array

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,14 +16,12 @@ export type OctokitOptions = {
 
 export type Constructor<T> = new (...args: any[]) => T;
 
-export type SimplifyEmpty<T> = T extends void | undefined | null ? void : T
-
 export type ReturnTypeOf<
   T extends AnyFunction | AnyFunction[]
 > = T extends AnyFunction
-  ? SimplifyEmpty<ReturnType<T>>
+  ? ReturnType<T>
   : T extends AnyFunction[]
-  ? UnionToIntersection<SimplifyEmpty<ReturnType<T[number]>>>
+  ? UnionToIntersection<ReturnType<T[number]>>
   : never;
 
 /**
@@ -41,4 +39,4 @@ type AnyFunction = (...args: any) => any;
 export type OctokitPlugin = (
   octokit: Octokit,
   options: OctokitOptions
-) => { [key: string]: any } | void | undefined;
+) => { [key: string]: any } | void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,19 +16,21 @@ export type OctokitOptions = {
 
 export type Constructor<T> = new (...args: any[]) => T;
 
+export type SimplifyEmpty<T> = T extends void | undefined | null ? void : T
+
 export type ReturnTypeOf<
   T extends AnyFunction | AnyFunction[]
 > = T extends AnyFunction
-  ? ReturnType<T>
+  ? SimplifyEmpty<ReturnType<T>>
   : T extends AnyFunction[]
-  ? UnionToIntersection<ReturnType<T[number]>>
+  ? UnionToIntersection<SimplifyEmpty<ReturnType<T[number]>>>
   : never;
 
 /**
  * @author https://stackoverflow.com/users/2887218/jcalz
  * @see https://stackoverflow.com/a/50375286/10325032
  */
-type UnionToIntersection<Union> = (Union extends any
+export type UnionToIntersection<Union> = (Union extends any
 ? (argument: Union) => void
 : never) extends (argument: infer Intersection) => void // tslint:disable-line: no-unused
   ? Intersection
@@ -39,4 +41,4 @@ type AnyFunction = (...args: any) => any;
 export type OctokitPlugin = (
   octokit: Octokit,
   options: OctokitOptions
-) => { [key: string]: any } | void;
+) => { [key: string]: any } | void | undefined;

--- a/test/__snapshots__/plugin.test.ts.snap
+++ b/test/__snapshots__/plugin.test.ts.snap
@@ -4,11 +4,11 @@ exports[`Octokit.plugin() supports array of plugins and warns of deprecated usag
 [MockFunction] {
   "calls": Array [
     Array [
-      "Passing an array of plugins to octokit.plugin() has been deprecated and support will be removed with v18.
+      "Passing an array of plugins to Octokit.plugin() has been deprecated.
 Instead of:
-  octokit.plugin([plugin1, plugin2, ...])
+  Octokit.plugin([plugin1, plugin2, ...])
 Use:
-  octokit.plugin(plugin1, plugin2, ...)",
+  Octokit.plugin(plugin1, plugin2, ...)",
     ],
   ],
   "results": Array [

--- a/test/__snapshots__/plugin.test.ts.snap
+++ b/test/__snapshots__/plugin.test.ts.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Octokit.plugin() supports array of plugins and warns of deprecated usage 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "Passing an array of plugins to octokit.plugin() has been deprecated and support will be removed with v18.
+Instead of:
+  octokit.plugin([plugin1, plugin2, ...])
+Use:
+  octokit.plugin(plugin1, plugin2, ...)",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;

--- a/test/__snapshots__/plugin.test.ts.snap
+++ b/test/__snapshots__/plugin.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Octokit.plugin() supports array of plugins 1`] = `
+exports[`Octokit.plugin() supports array of plugins and warns of deprecated usage 1`] = `
 [MockFunction] {
   "calls": Array [
     Array [

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -17,11 +17,14 @@ describe("Octokit.plugin()", () => {
     expect(myClient.foo).toEqual("bar");
   });
 
-  it("supports array of plugins", () => {
+  it("supports array of plugins and warns of deprecated usage", () => {
+    const warningSpy = jest.spyOn(console, "warn").mockImplementation();
     const MyOctokit = Octokit.plugin([pluginFoo, pluginBaz]);
     const myClient = new MyOctokit();
     expect(myClient.foo).toEqual("bar");
     expect(myClient.baz).toEqual("daz");
+    expect(warningSpy).toMatchSnapshot();
+    warningSpy.mockClear();
   });
 
   it("supports multiple plugins", () => {

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -1,38 +1,38 @@
 import { Octokit } from "../src";
 
+const pluginFoo = () => {
+  return { foo: "bar" };
+};
+const pluginBaz = () => {
+  return { baz: "daz" };
+};
+const pluginQaz = () => {
+  return { qaz: "naz" };
+};
+
 describe("Octokit.plugin()", () => {
   it("gets called in constructor", () => {
-    const MyOctokit = Octokit.plugin(() => {
-      return {
-        foo: "bar"
-      };
-    });
+    const MyOctokit = Octokit.plugin(pluginFoo);
     const myClient = new MyOctokit();
     expect(myClient.foo).toEqual("bar");
   });
 
   it("supports array of plugins", () => {
-    const MyOctokit = Octokit.plugin([
-      () => {
-        return {
-          foo: "bar"
-        };
-      },
-      () => {
-        return { baz: "daz" };
-      }
-    ]);
+    const MyOctokit = Octokit.plugin([pluginFoo, pluginBaz]);
     const myClient = new MyOctokit();
     expect(myClient.foo).toEqual("bar");
     expect(myClient.baz).toEqual("daz");
   });
 
+  it("supports multiple plugins", () => {
+    const MyOctokit = Octokit.plugin(pluginFoo, pluginBaz, pluginQaz);
+    const myClient = new MyOctokit();
+    expect(myClient.foo).toEqual("bar");
+    expect(myClient.baz).toEqual("daz");
+    expect(myClient.qaz).toEqual("naz");
+  });
   it("does not override plugins of original constructor", () => {
-    const MyOctokit = Octokit.plugin(octokit => {
-      return {
-        foo: "bar"
-      };
-    });
+    const MyOctokit = Octokit.plugin(pluginFoo);
     const myClient = new MyOctokit();
     expect(myClient.foo).toEqual("bar");
 
@@ -64,17 +64,9 @@ describe("Octokit.plugin()", () => {
   });
 
   it("supports chaining", () => {
-    const MyOctokit = Octokit.plugin(() => {
-      return {
-        foo: "bar"
-      };
-    })
-      .plugin(() => {
-        return { baz: "daz" };
-      })
-      .plugin(() => {
-        return { qaz: "naz" };
-      });
+    const MyOctokit = Octokit.plugin(pluginFoo)
+      .plugin(pluginBaz)
+      .plugin(pluginQaz);
 
     const myClient = new MyOctokit();
     expect(myClient.foo).toEqual("bar");


### PR DESCRIPTION
From the ideas that have been thrown out there to solve the issue described in #51, this is my favorite.

Instead of `.plugin(arrayOfPlugins[])`, which could lead to a type-widening error, this PR moves to use `.plugin(plugin1, plugin2, plugin3, etc...)`, where each plugin is hardcoded into the type-system

Why this approach?

I think this will be easiest on plugin authors, who don't have to change anything with how they currently develop plugins - such as having to worry about whether they need to return an object, if they return void, etc.

This will also be an easy fix for users of Octokit. `.plugin([paginateRest, queueWorker, logService])` becomes `.plugin(paginateRest, queueWorker, logService)`

**TODOs**

- [x] Continue to accept arrays as an argument (aka backward-compatible with the previous syntax)
- [x] Warn users that the syntax has changed. Provide an example of the changed syntax.

Example warning when using old syntax:

![corejs-non-array-warning](https://user-images.githubusercontent.com/10104630/77239217-4a5b0680-6b95-11ea-9b2e-3e51faa7b112.png)


Fixes #51