### PR TITLE
Add missing types for `OctokitOptions`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -13,10 +13,10 @@ export type OctokitOptions = {
   previews?: string[];
   baseUrl?: string;
   log?: {
-    debug: () => unknown;
-    info: () => unknown;
-    warn: () => unknown;
-    error: () => unknown;
+    debug: (message: string) => unknown;
+    info: (message: string) => unknown;
+    warn: (message: string) => unknown;
+    error: (message: string) => unknown;
   };
   request?: OctokitTypes.RequestRequestOptions;
   timeZone?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,7 @@ export type OctokitOptions = {
     error: () => unknown;
   };
   request?: OctokitTypes.RequestRequestOptions;
-  timeZone?: string; 
+  timeZone?: string;
   [option: string]: any;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,8 +9,17 @@ export type OctokitOptions = {
   //       see https://tinyurl.com/typescript-auth-strategies
   authStrategy?: any;
   auth?: any;
+  userAgent?: string;
+  previews?: string[];
+  baseUrl?: string;
+  log?: {
+    debug: () => unknown;
+    info: () => unknown;
+    warn: () => unknown;
+    error: () => unknown;
+  };
   request?: OctokitTypes.RequestRequestOptions;
-  timeZone?: string;
+  timeZone?: string; 
   [option: string]: any;
 };
 


### PR DESCRIPTION
This PRs adds types for the options specified in the [rest.js docs](https://octokit.github.io/rest.js/v18#usage)

**Before:**
<img src="https://user-images.githubusercontent.com/209966/89132952-25e64200-d518-11ea-9051-e95ec0819a3f.png" width="500"/>

**After:**
<img src="https://user-images.githubusercontent.com/209966/89132960-42827a00-d518-11ea-8241-2a6b99466fa6.png" width="500"/>


