### PR TITLE
docs(README): `plugin-throttle` should be `plugin-throttling`, `plugin-paginate` should be `plugin-paginate-rest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ You can build your own Octokit class with preset default options and plugins. In
 const { Octokit } = require("@octokit/core");
 const MyActionOctokit = Octokit.plugin(
   require("@octokit/plugin-paginate"),
-  require("@octokit/plugin-throttle"),
+  require("@octokit/plugin-throttling"),
   require("@octokit/plugin-retry")
 ).defaults({
   authStrategy: require("@octokit/auth-action"),

--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ You can build your own Octokit class with preset default options and plugins. In
 ```js
 const { Octokit } = require("@octokit/core");
 const MyActionOctokit = Octokit.plugin(
-  require("@octokit/plugin-paginate"),
+  require("@octokit/plugin-paginate-rest"),
   require("@octokit/plugin-throttling"),
   require("@octokit/plugin-retry")
 ).defaults({


### PR DESCRIPTION
Typos in the README.