### PR TITLE
feat(auth): pass `octokit` and `octokitOptions` to `options.authStrategy`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -135,11 +135,19 @@ export class Octokit {
         this.auth = auth;
       }
     } else {
-      const auth = options.authStrategy(
+      const { authStrategy, ...otherOptions } = options;
+      const auth = authStrategy(
         Object.assign(
           {
             request: this.request,
             log: this.log,
+            // we pass the current octokit instance as well as its constructor options
+            // to allow for authentication strategies that return a new octokit instance
+            // that shares the same internal state as the current one. The original
+            // requirement for this was the "event-octokit" authentication strategy
+            // of https://github.com/probot/octokit-auth-probot.
+            octokit: this,
+            octokitOptions: otherOptions,
           },
           options.auth
         )

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -395,4 +395,33 @@ describe("Authentication", () => {
       "[@octokit/auth-app] Retrying after 401 response to account for token replication delay (retry: 1, wait: 1s)"
     );
   });
+
+  it("should pass octokit and octokitOptions if a custom authStrategy was set", () => {
+    const authStrategy = jest.fn().mockReturnValue({
+      hook() {},
+    });
+    new Octokit({
+      authStrategy,
+      auth: {
+        secret: "123",
+      },
+      someUnrelatedOption: "value",
+    });
+
+    const strategyOptions = authStrategy.mock.calls[0][0];
+
+    expect(Object.keys(strategyOptions).sort()).toStrictEqual([
+      "log",
+      "octokit",
+      "octokitOptions",
+      "request",
+      "secret",
+    ]);
+    expect(strategyOptions.octokitOptions).toStrictEqual({
+      auth: {
+        secret: "123",
+      },
+      someUnrelatedOption: "value",
+    });
+  });
 });


### PR DESCRIPTION
unblocks probot/octokit-auth-probot#1