### PR TITLE
feat(typescript): types for `octokit.hook.{before,after,error,wrap}("request", () => {})` methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1865,11 +1865,11 @@
       }
     },
     "@octokit/types": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.12.1.tgz",
-      "integrity": "sha512-eZTTWJxGBon01Ra4EX86rvlMZGkU5SeJ8BtwQlsv2wEqZttpjtefLetJndZTVbJ25qFKoyKMWsRFnwlOx7ZaDQ==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.12.0.tgz",
+      "integrity": "sha512-KwOf16soD7aDEEi/PgNeJlHzjZPfrmmNy+7WezSdrpnqZ7YImBJcNnX9+5RUHt1MnA4h8oISRHTqaZDGsX9DRQ==",
       "requires": {
-        "@octokit/openapi-types": "^5.3.1"
+        "@octokit/openapi-types": "^5.3.0"
       }
     },
     "@pika/babel-plugin-esm-import-rewrite": {
@@ -3255,9 +3255,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001197",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001197.tgz",
-      "integrity": "sha512-8aE+sqBqtXz4G8g35Eg/XEaFr2N7rd/VQ6eABGBmNtcB8cN6qNJhMi6oSFy4UWWZgqgL3filHT8Nha4meu3tsw==",
+      "version": "1.0.30001196",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001196.tgz",
+      "integrity": "sha512-CPvObjD3ovWrNBaXlAIGWmg2gQQuJ5YhuciUOjPRox6hIQttu8O+b51dx6VIpIY9ESd2d0Vac1RKpICdG4rGUg==",
       "dev": true
     },
     "capture-exit": {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
     "@octokit/auth-token": "^2.4.4",
     "@octokit/graphql": "^4.5.8",
     "@octokit/request": "^5.4.12",
+    "@octokit/request-error": "^2.0.5",
     "@octokit/types": "^6.0.3",
-    "before-after-hook": "^2.1.0",
+    "before-after-hook": "^2.2.0",
     "universal-user-agent": "^6.0.0"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { createTokenAuth } from "@octokit/auth-token";
 
 import {
   Constructor,
+  Hooks,
   OctokitOptions,
   OctokitPlugin,
   RequestParameters,
@@ -70,11 +71,12 @@ export class Octokit {
   }
 
   constructor(options: OctokitOptions = {}) {
-    const hook = new Collection();
+    const hook = new Collection<Hooks>();
     const requestDefaults: Required<RequestParameters> = {
       baseUrl: request.endpoint.DEFAULTS.baseUrl,
       headers: {},
       request: Object.assign({}, options.request, {
+        // @ts-ignore internal usage only, no need to type
         hook: hook.bind(null, "request"),
       }),
       mediaType: {
@@ -175,7 +177,7 @@ export class Octokit {
     error: (message: string, additionalInfo?: object) => any;
     [key: string]: any;
   };
-  hook: HookCollection;
+  hook: HookCollection<Hooks>;
 
   // TODO: type `octokit.auth` based on passed options.authStrategy
   auth: (...args: unknown[]) => Promise<unknown>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import * as OctokitTypes from "@octokit/types";
+import { RequestError } from "@octokit/request-error";
 
 import { Octokit } from ".";
 
@@ -49,3 +50,16 @@ export type OctokitPlugin = (
   octokit: Octokit,
   options: OctokitOptions
 ) => { [key: string]: any } | void;
+
+export type Hooks = {
+  request: {
+    Options: OctokitTypes.EndpointOptions;
+    Result: OctokitTypes.OctokitResponse<any>;
+    Error: RequestError | Error;
+  };
+  [key: string]: {
+    Options: unknown;
+    Result: unknown;
+    Error: unknown;
+  };
+};

--- a/test/constructor.test.ts
+++ b/test/constructor.test.ts
@@ -58,15 +58,21 @@ describe("Smoke test", () => {
     });
 
     octokit.hook.wrap("request", (request, options) => {
+      // @ts-ignore
       expect(options.request.foo).toEqual("bar");
-      return "ok";
+      return {
+        data: { ok: true },
+        headers: {},
+        status: 200,
+        url: "https://example.com",
+      };
     });
 
     return octokit
       .request("/")
 
       .then((response) => {
-        expect(response).toEqual("ok");
+        expect(response.data.ok).toEqual(true);
       });
   });
 });

--- a/test/hook.test.ts
+++ b/test/hook.test.ts
@@ -61,6 +61,7 @@ describe("octokit.hook", () => {
         qux: "quux",
         request: {
           fetch: mock,
+          // @ts-ignore
           hook: options.request.hook,
         },
       });
@@ -180,11 +181,12 @@ describe("octokit.hook", () => {
           format: "",
         },
         request: {
+          // @ts-ignore
           hook: options.request.hook,
         },
       });
 
-      return { data: { ok: true } };
+      return { data: { ok: true }, headers: {}, status: 200, url: "" };
     });
 
     const { data } = await octokit.request("/");


### PR DESCRIPTION
Shout out to @MunifTanjim who made this possible via https://github.com/gr2m/before-after-hook/pull/81

<img width="626" alt="image" src="https://user-images.githubusercontent.com/39992/110178878-f3f1d280-7dbb-11eb-98f5-3f162a88678b.png">
