### PR TITLE
fix(typescript): remove `[key: string]: any` from `Octokit` class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -181,6 +181,4 @@ export class Octokit {
 
   // TODO: type `octokit.auth` based on passed options.authStrategy
   auth: (...args: unknown[]) => Promise<unknown>;
-
-  [key: string]: any;
 }


### PR DESCRIPTION
Before any property on an `octokit` instance could be used without complaint at build time. With this change, all additional properties on an `octokit` instance need to be added explicitly using plugins