### PR TITLE
feat(typescript): do not permit unknown keys on `octokit` instance'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,9 @@ name: Test
     types:
       - opened
       - synchronize
+
 jobs:
-  test:
+  test_matrix:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -16,11 +17,27 @@ jobs:
           - 10
           - 12
           - 14
+
     steps:
       - uses: actions/checkout@v2
-      - name: "Use Node.js ${{ matrix.node_version }}"
+      - name: Use Node.js ${{ matrix.node_version }}
         uses: actions/setup-node@v2
         with:
-          node-version: "${{ matrix.node_version }}"
+          node-version: ${{ matrix.node_version }}
+      - uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
       - run: npm ci
-      - run: npm test
+      - run: npm test --ignore-scripts # run lint only once
+
+  test:
+    runs-on: ubuntu-latest
+    needs: test_matrix
+    steps:
+      - uses: actions/checkout@v2
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run test:typescript

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "prettier --check '{src,test}/**/*.{ts,md}' README.md package.json",
     "lint:fix": "prettier --write '{src,test}/**/*.{ts,md}' README.md package.json",
     "pretest": "npm run -s lint",
-    "test": "jest --coverage"
+    "test": "jest --coverage",
+    "test:typescript": "npx tsc --noEmit --declaration --noUnusedLocals test/typescript-validate.ts"
   },
   "repository": "github:octokit/core.js",
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ export class Octokit {
       }
     };
 
-    return OctokitWithDefaults;
+    return OctokitWithDefaults as typeof this;
   }
 
   static plugins: OctokitPlugin[] = [];
@@ -66,7 +66,7 @@ export class Octokit {
       );
     };
 
-    return NewOctokit as typeof NewOctokit &
+    return NewOctokit as typeof this &
       Constructor<UnionToIntersection<ReturnTypeOf<T>>>;
   }
 

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -1,0 +1,39 @@
+// ************************************************************
+// THIS CODE IS NOT EXECUTED. IT IS JUST FOR TYPECHECKING
+// ************************************************************
+
+import { Octokit } from "../src";
+
+export function pluginsTest() {
+  // `octokit` instance does not permit unknown keys
+  const octokit = new Octokit();
+
+  // @ts-expect-error Property 'unknown' does not exist on type 'Octokit'.(2339)
+  octokit.unknown;
+
+  const OctokitWithDefaults = Octokit.defaults({});
+  const octokitWithDefaults = new OctokitWithDefaults();
+
+  // Error: `octokitWithDefaults` does permit unknown keys
+  // @ts-expect-error `.unknown` should not be typed as `any`
+  octokitWithDefaults.unknown;
+
+  const OctokitWithPlugin = Octokit.plugin(() => ({}));
+  const octokitWithPlugin = new OctokitWithPlugin();
+
+  // Error: `octokitWithPlugin` does permit unknown keys
+  // @ts-expect-error `.unknown` should not be typed as `any`
+  octokitWithPlugin.unknown;
+
+  const OctokitWithPluginAndDefaults = Octokit.plugin(() => ({
+    foo: 42,
+  })).defaults({
+    baz: "daz",
+  });
+
+  const octokitWithPluginAndDefaults = new OctokitWithPluginAndDefaults();
+
+  octokitWithPluginAndDefaults.foo;
+  // @ts-expect-error `.unknown` should not be typed as `any`
+  octokitWithPluginAndDefaults.unknown;
+}


### PR DESCRIPTION
implements changes suggested by @Andarist at https://github.com/gr2m/javascript-plugin-architecture-with-typescript-definitions/issues/31
