### PR TITLE
fix(typescript): avoid the `void`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,8 @@ export type ReturnTypeOf<T extends AnyFunction | AnyFunction[]> =
   T extends AnyFunction
     ? ReturnType<T>
     : T extends AnyFunction[]
-    ? UnionToIntersection<ReturnType<T[number]>>
+    ? // exclude `void` from intersection, see octokit/octokit.js#2115
+      UnionToIntersection<Exclude<ReturnType<T[number]>, void>>
     : never;
 
 /**

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -4,6 +4,8 @@
 
 import { Octokit } from "../src";
 
+export function expectType<T>(what: T) {}
+
 export function pluginsTest() {
   // `octokit` instance does not permit unknown keys
   const octokit = new Octokit();
@@ -36,4 +38,18 @@ export function pluginsTest() {
   octokitWithPluginAndDefaults.foo;
   // @ts-expect-error `.unknown` should not be typed as `any`
   octokitWithPluginAndDefaults.unknown;
+
+  // https://github.com/octokit/octokit.js/issues/2115
+  const OctokitWithVoidAndNonVoidPlugins = Octokit.plugin(
+    () => ({ foo: "foo" }),
+    () => {},
+    () => ({ bar: "bar" })
+  );
+  const octokitWithVoidAndNonVoidPlugins =
+    new OctokitWithVoidAndNonVoidPlugins();
+
+  // @ts-expect-error octokitWithVoidAndNonVoidPlugins must never be `void`, even if one of the plugins returns `void`
+  expectType<void>(octokitWithVoidAndNonVoidPlugins);
+  expectType<string>(octokitWithVoidAndNonVoidPlugins.foo);
+  expectType<string>(octokitWithVoidAndNonVoidPlugins.bar);
 }


### PR DESCRIPTION
prevents the `octokit` instance from becoming an intersection with `void`, see https://github.com/octokit/octokit.js/issues/2115
