### PR TITLE
docs(README): fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ If you need a deep or conditional merge, you can pass a function instead.
 ```js
 const MyOctokit = Octokit.defaults((options) => {
   return {
-    foo: Object.assign({}, options.foo, { opt2: 1 }),
+    foo: Object.assign({}, options.foo, { opt1: 1 }),
   };
 });
 const octokit = new MyOctokit({


### PR DESCRIPTION
According to the expected result in the comment in the example, this property should be named `opt1`.