### PR TITLE
ci(codeql): ignore on push events for dependabot branches

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,7 +1,9 @@
 name: Code scanning - action
 "on":
-  push: null
-  pull_request: null
+  push:
+    branches-ignore:
+      - "dependabot/**"
+  pull_request:
   schedule:
     - cron: 0 19 * * 0
 jobs:


### PR DESCRIPTION
# Description
Do not run codeql.yml for dependabot branches

# Context
https://github.com/octokit/plugin-paginate-rest.js/pull/376