### PR TITLE
fix(deps): revert breaking dependency changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@octokit/graphql": "^5.0.0",
         "@octokit/request": "^6.0.0",
         "@octokit/request-error": "^4.0.0",
-        "@octokit/types": "^10.0.0",
+        "@octokit/types": "^9.0.0",
         "before-after-hook": "^2.2.0",
         "universal-user-agent": "^6.0.0"
       },
@@ -2396,19 +2396,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
-      "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw=="
-    },
-    "node_modules/@octokit/request-error/node_modules/@octokit/types": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-      "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
-      }
-    },
     "node_modules/@octokit/request/node_modules/@octokit/endpoint": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.0.tgz",
@@ -2459,17 +2446,17 @@
       "dev": true
     },
     "node_modules/@octokit/types": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
-      "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.0.0.tgz",
+      "integrity": "sha512-LUewfj94xCMH2rbD5YJ+6AQ4AVjFYTgpp6rboWM5T7N3IsIF65SBEOVcYMGAEzO/kKNiNaW4LoWtoThOhH06gw==",
       "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
+        "@octokit/openapi-types": "^16.0.0"
       }
     },
     "node_modules/@octokit/types/node_modules/@octokit/openapi-types": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
-      "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw=="
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-16.0.0.tgz",
+      "integrity": "sha512-JbFWOqTJVLHZSUUoF4FzAZKYtqdxWu9Z5m2QQnOyEa04fOFljvyh7D3GYKbfuaSWisqehImiVIMG4eyJeP5VEA=="
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -15241,21 +15228,6 @@
         "@octokit/types": "^9.0.0",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
-      },
-      "dependencies": {
-        "@octokit/openapi-types": {
-          "version": "18.0.0",
-          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
-          "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw=="
-        },
-        "@octokit/types": {
-          "version": "9.3.2",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-          "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-          "requires": {
-            "@octokit/openapi-types": "^18.0.0"
-          }
-        }
       }
     },
     "@octokit/rest": {
@@ -15277,17 +15249,17 @@
       "dev": true
     },
     "@octokit/types": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
-      "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.0.0.tgz",
+      "integrity": "sha512-LUewfj94xCMH2rbD5YJ+6AQ4AVjFYTgpp6rboWM5T7N3IsIF65SBEOVcYMGAEzO/kKNiNaW4LoWtoThOhH06gw==",
       "requires": {
-        "@octokit/openapi-types": "^18.0.0"
+        "@octokit/openapi-types": "^16.0.0"
       },
       "dependencies": {
         "@octokit/openapi-types": {
-          "version": "18.0.0",
-          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
-          "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw=="
+          "version": "16.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-16.0.0.tgz",
+          "integrity": "sha512-JbFWOqTJVLHZSUUoF4FzAZKYtqdxWu9Z5m2QQnOyEa04fOFljvyh7D3GYKbfuaSWisqehImiVIMG4eyJeP5VEA=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@octokit/auth-token": "^3.0.0",
         "@octokit/graphql": "^5.0.0",
         "@octokit/request": "^6.0.0",
-        "@octokit/request-error": "^4.0.0",
+        "@octokit/request-error": "^3.0.0",
         "@octokit/types": "^9.0.0",
         "before-after-hook": "^2.2.0",
         "universal-user-agent": "^6.0.0"
@@ -2384,16 +2384,24 @@
       }
     },
     "node_modules/@octokit/request-error": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-4.0.1.tgz",
-      "integrity": "sha512-DBTkqzs0K6SlK1gRaQ6A6yOnKKkbVy8n/A9E7Es5qYONIxBghqiETPqWhG9l7qvWgp8v3sDkB8vlV2AAX1N6gw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.0.tgz",
+      "integrity": "sha512-WBtpzm9lR8z4IHIMtOqr6XwfkGvMOOILNLxsWvDwtzm/n7f5AWuqJTXQXdDtOvPfTDrH4TPhEvW2qMlR4JFA2w==",
       "dependencies": {
-        "@octokit/types": "^9.0.0",
+        "@octokit/types": "^6.0.3",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/request-error/node_modules/@octokit/types": {
+      "version": "6.41.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
+      "integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
+      "dependencies": {
+        "@octokit/openapi-types": "^12.11.0"
       }
     },
     "node_modules/@octokit/request/node_modules/@octokit/endpoint": {
@@ -15221,13 +15229,23 @@
       }
     },
     "@octokit/request-error": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-4.0.1.tgz",
-      "integrity": "sha512-DBTkqzs0K6SlK1gRaQ6A6yOnKKkbVy8n/A9E7Es5qYONIxBghqiETPqWhG9l7qvWgp8v3sDkB8vlV2AAX1N6gw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.0.tgz",
+      "integrity": "sha512-WBtpzm9lR8z4IHIMtOqr6XwfkGvMOOILNLxsWvDwtzm/n7f5AWuqJTXQXdDtOvPfTDrH4TPhEvW2qMlR4JFA2w==",
       "requires": {
-        "@octokit/types": "^9.0.0",
+        "@octokit/types": "^6.0.3",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
+      },
+      "dependencies": {
+        "@octokit/types": {
+          "version": "6.41.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
+          "integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
+          "requires": {
+            "@octokit/openapi-types": "^12.11.0"
+          }
+        }
       }
     },
     "@octokit/rest": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@octokit/auth-token": "^3.0.0",
     "@octokit/graphql": "^5.0.0",
     "@octokit/request": "^6.0.0",
-    "@octokit/request-error": "^4.0.0",
+    "@octokit/request-error": "^3.0.0",
     "@octokit/types": "^9.0.0",
     "before-after-hook": "^2.2.0",
     "universal-user-agent": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@octokit/graphql": "^5.0.0",
     "@octokit/request": "^6.0.0",
     "@octokit/request-error": "^4.0.0",
-    "@octokit/types": "^10.0.0",
+    "@octokit/types": "^9.0.0",
     "before-after-hook": "^2.2.0",
     "universal-user-agent": "^6.0.0"
   },


### PR DESCRIPTION
Fixes #575 and reverts the breaking dependency changes that prematurely dropped support for Node 14/16. 