### PR TITLE
Rewrites the ca tests to use the dispatcher and custom fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,8 @@
         "semantic-release": "^21.0.0",
         "semantic-release-plugin-update-version-in-files": "^1.0.0",
         "ts-jest": "^29.0.0",
-        "typescript": "^5.0.0"
+        "typescript": "^5.0.0",
+        "undici": "5.22.1"
       },
       "engines": {
         "node": ">= 18"
@@ -2735,6 +2736,18 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dev": true,
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -11834,6 +11847,15 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -12389,6 +12411,18 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.22.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
+      "integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
+      "dev": true,
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/unique-string": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "semantic-release": "^21.0.0",
     "semantic-release-plugin-update-version-in-files": "^1.0.0",
     "ts-jest": "^29.0.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "undici": "5.22.1"
   },
   "jest": {
     "transform": {

--- a/test/agent-ca/agent-ca-test.test.ts
+++ b/test/agent-ca/agent-ca-test.test.ts
@@ -1,18 +1,27 @@
-import { Agent, createServer } from "https";
+import { createServer } from "https";
 import { readFileSync } from "fs";
 import { resolve } from "path";
+import { fetch as undiciFetch, Agent } from "undici";
+import { request } from "@octokit/request";
 
-const { Octokit } = require("../../src");
 const ca = readFileSync(resolve(__dirname, "./ca.crt"));
 
 // TODO: rewrite tests to use fetch dispatchers
-describe.skip("custom client certificate", () => {
+describe("custom client certificate", () => {
   let server: any;
+  // let myFetch: any;
+
   beforeAll((done) => {
+
+    // Stand up a server that requires a client certificate
+    // requestCert forces the server to request a certificate
+    // rejectUnauthorized: false allows us to test with a self-signed certificate
     server = createServer(
       {
         key: readFileSync(resolve(__dirname, "./localhost.key")),
         cert: readFileSync(resolve(__dirname, "./localhost.crt")),
+        requestCert: true,
+        rejectUnauthorized: false,
       },
       (request: any, response: any) => {
         expect(request.method).toEqual("GET");
@@ -28,28 +37,55 @@ describe.skip("custom client certificate", () => {
   });
 
   it("https.Agent({ca})", () => {
-    const agent = new Agent({
-      ca,
-    });
-    const octokit = new Octokit({
-      baseUrl: "https://localhost:" + server.address().port,
-      request: { agent },
-    });
 
-    return octokit.request("/");
+    // Setup a dispatcher that uses the undici agent
+    const agent = new Agent({
+      keepAliveTimeout: 10,
+      keepAliveMaxTimeout: 10,
+      connect: {ca: ca}
+    })
+
+    const myFetch = (url: any, opts: any) => {
+      return undiciFetch(url, {
+        ...opts,
+        dispatcher: agent,
+      });
+    };
+
+    return request("/", {
+      options: {
+        baseUrl: "https://localhost:" + server.address().port,
+        request: {
+          fetch: myFetch,
+        },
+      },
+    });
   });
 
   it("https.Agent({ca, rejectUnauthorized})", () => {
-    const agent = new Agent({
-      ca: "invalid",
-      rejectUnauthorized: false,
-    });
-    const octokit = new Octokit({
-      baseUrl: "https://localhost:" + server.address().port,
-      request: { agent },
-    });
 
-    return octokit.request("/");
+    // Setup a dispatcher that uses the undici agent
+    const agent = new Agent({
+      keepAliveTimeout: 10,
+      keepAliveMaxTimeout: 10,
+      connect: {ca: "invalid"}
+    })
+
+    const myFetch = (url: any, opts: any) => {
+      return undiciFetch(url, {
+        ...opts,
+        dispatcher: agent,
+      });
+    };
+
+    return request("/", {
+      options: {
+        baseUrl: "https://localhost:" + server.address().port,
+        request: {
+          fetch: myFetch,
+        },
+      },
+    });
   });
 
   afterAll((done) => {

--- a/test/agent-ca/agent-ca-test.test.ts
+++ b/test/agent-ca/agent-ca-test.test.ts
@@ -12,7 +12,6 @@ describe("custom client certificate", () => {
   // let myFetch: any;
 
   beforeAll((done) => {
-
     // Stand up a server that requires a client certificate
     // requestCert forces the server to request a certificate
     // rejectUnauthorized: false allows us to test with a self-signed certificate
@@ -37,13 +36,12 @@ describe("custom client certificate", () => {
   });
 
   it("https.Agent({ca})", () => {
-
     // Setup a dispatcher that uses the undici agent
     const agent = new Agent({
       keepAliveTimeout: 10,
       keepAliveMaxTimeout: 10,
-      connect: {ca: ca}
-    })
+      connect: { ca: ca },
+    });
 
     const myFetch = (url: any, opts: any) => {
       return undiciFetch(url, {
@@ -63,13 +61,12 @@ describe("custom client certificate", () => {
   });
 
   it("https.Agent({ca, rejectUnauthorized})", () => {
-
     // Setup a dispatcher that uses the undici agent
     const agent = new Agent({
       keepAliveTimeout: 10,
       keepAliveMaxTimeout: 10,
-      connect: {ca: "invalid"}
-    })
+      connect: { ca: "invalid" },
+    });
 
     const myFetch = (url: any, opts: any) => {
       return undiciFetch(url, {


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
RE: https://github.com/octokit/core.js/pull/563

Now that we have introduced the changes for removing agent from octokit.request we needed to rework some tests to use the new patterns.  

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The CA tests were skipped

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* They have now been rewritten to use a dispatcher and custom fetch

