### PR TITLE
test(agent-proxy): restore test coverage with `undici`

### DIFF
--- a/test/agent-ca/agent-ca-test.test.ts
+++ b/test/agent-ca/agent-ca-test.test.ts
@@ -1,14 +1,14 @@
-import { createServer } from "https";
+import { createServer, type Server } from "https";
 import { readFileSync } from "fs";
 import { resolve } from "path";
 import { fetch as undiciFetch, Agent } from "undici";
 import { request } from "@octokit/request";
+import { type AddressInfo } from "net";
 
 const ca = readFileSync(resolve(__dirname, "./ca.crt"));
 
-// TODO: rewrite tests to use fetch dispatchers
 describe("custom client certificate", () => {
-  let server: any;
+  let server: Server;
   // let myFetch: any;
 
   beforeAll((done) => {
@@ -52,7 +52,7 @@ describe("custom client certificate", () => {
 
     return request("/", {
       options: {
-        baseUrl: "https://localhost:" + server.address().port,
+        baseUrl: "https://localhost:" + (server.address() as AddressInfo).port,
         request: {
           fetch: myFetch,
         },
@@ -68,7 +68,7 @@ describe("custom client certificate", () => {
       connect: { ca: "invalid" },
     });
 
-    const myFetch = (url: any, opts: any) => {
+    const myFetch: typeof undiciFetch = (url, opts) => {
       return undiciFetch(url, {
         ...opts,
         dispatcher: agent,
@@ -77,7 +77,7 @@ describe("custom client certificate", () => {
 
     return request("/", {
       options: {
-        baseUrl: "https://localhost:" + server.address().port,
+        baseUrl: "https://localhost:" + (server.address() as AddressInfo).port,
         request: {
           fetch: myFetch,
         },

--- a/test/agent-ca/agent-ca-test.test.ts
+++ b/test/agent-ca/agent-ca-test.test.ts
@@ -9,7 +9,6 @@ const ca = readFileSync(resolve(__dirname, "./ca.crt"));
 
 describe("custom client certificate", () => {
   let server: Server;
-  // let myFetch: any;
 
   beforeAll((done) => {
     // Stand up a server that requires a client certificate

--- a/test/agent-proxy/agent-proxy-test.test.ts
+++ b/test/agent-proxy/agent-proxy-test.test.ts
@@ -1,44 +1,57 @@
 /*!
  * Tests are based on work by Nathan Rajlich:
  * https://github.com/TooTallNate/node-http-proxy-agent/blob/65307ac8fe4e6ce1a2685d21ec4affa4c2a0a30d/test/test.js
- *
  * Copyright (c) 2013 Nathan Rajlich <nathan@tootallnate.net>
  * Released under the MIT license
+ *
+ * and on work by Rafael Gonzaga (https://github.com/RafaelGSS)
+ *
+ * https://github.com/nodejs/undici/blob/512cdadc403874571cd5035a6c41debab1165310/test/proxy-agent.js#L370-L418
+ * Released under the MIT license
  */
-import { createServer } from "http";
+import { Server, createServer } from "http";
 import { type AddressInfo } from "net";
-import { createProxy } from "proxy";
-import { fetch as undiciFetch, ProxyAgent } from "undici";
+import { ProxyServer, createProxy } from "proxy";
+import { ProxyAgent, fetch as undiciFetch } from "undici";
 import { Octokit } from "../../src";
 
-const server = createServer();
-server.listen(0, () => {});
-
-const proxyServer = createProxy();
-proxyServer.listen(0, () => {});
-
-const serverUrl = `http://localhost:${(server.address() as AddressInfo).port}`;
-const proxyUrl = `http://localhost:${
-  (proxyServer.address() as AddressInfo).port
-}`;
-
-server.on("request", (request, response) => {
-  expect(request.method).toEqual("GET");
-  expect(request.url).toEqual("/");
-
-  response.writeHead(200);
-  response.write("ok");
-  response.end();
-});
-
 describe("client proxy", () => {
-  it("options.request.fetch = customFetch with dispatcher: new ProxyAgent(proxyUrl)", async () => {
-    let proxyReceivedRequest = false;
+  let server: Server;
+  let proxyServer: ProxyServer;
+  let serverUrl: string;
+  let proxyUrl: string;
 
-    proxyServer.on("request", (request) => {
-      console.log("proxyRequest", request.headers);
+  beforeEach(() => {
+    server = createServer();
+    server.listen(0, () => {});
+
+    proxyServer = createProxy();
+    proxyServer.listen(0, () => {});
+
+    serverUrl = `http://localhost:${(server.address() as AddressInfo).port}`;
+    proxyUrl = `http://localhost:${
+      (proxyServer.address() as AddressInfo).port
+    }`;
+  });
+
+  it("options.request.fetch = customFetch with dispatcher: new ProxyAgent(proxyUrl)", async () => {
+    let proxyConnectionEstablished = false;
+
+    // requests are not exposed to the proxy server, they are tunneled to
+    // Reference: https://github.com/advisories/GHSA-pgw7-wx7w-2w33
+    // Commit: https://github.com/nodejs/undici/commit/df4f7e0e95f5112322a96fd7a666cb28c1d48327#diff-90964a82994d6c63f28161d5410c64406e6abdee4ac0759e83b1abbbe469cda4L35-R39
+    proxyServer.on("connect", () => {
+      proxyConnectionEstablished = true;
+    });
+
+    server.on("request", (request, response) => {
+      expect(request.method).toEqual("GET");
+      expect(request.url).toEqual("/");
       expect(request.headers.accept).toBe("application/vnd.github.v3+json");
-      proxyReceivedRequest = true;
+
+      response.writeHead(200);
+      response.write("ok");
+      response.end();
     });
 
     const myFetch: typeof undiciFetch = (url, opts) => {
@@ -59,7 +72,12 @@ describe("client proxy", () => {
 
     await octokit.request("/");
 
-    expect(proxyReceivedRequest).toBe(true);
+    expect(proxyConnectionEstablished).toBeTruthy();
     expect.assertions(4);
+  });
+
+  afterEach(() => {
+    server.close();
+    proxyServer.close();
   });
 });


### PR DESCRIPTION
- refactor(agent-ca-test): improve types
- test(agent-proxy): restore test coverage with undici

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #586 

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Tests for `agent-proxy` were skipped

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Tests for `agent-proxy` are restored using `undici`


### Other information
<!-- Any other information that is important to this PR  -->

* https://undici.nodejs.org/

----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:

* N/A


### Pull request type
`Type: Maintenance`

----

