### PR TITLE
refactor: use `node:` specifier imports and full relative path imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:fix": "prettier --write '{src,test}/**/*.{ts,md}' README.md package.json",
     "pretest": "npm run -s lint",
     "test": "jest --coverage",
-    "test:typescript": "npx tsc --noEmit --declaration --noUnusedLocals test/typescript-validate.ts"
+    "test:typescript": "npx tsc --noEmit --declaration --noUnusedLocals --allowImportingTsExtensions test/typescript-validate.ts"
   },
   "repository": "github:octokit/core.js",
   "keywords": [
@@ -72,6 +72,9 @@
         "functions": 100,
         "lines": 100
       }
+    },
+    "moduleNameMapper": {
+      "^(.+)\\.jsx?$": "$1"
     }
   },
   "release": {

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,6 +1,6 @@
 // @ts-check
 import esbuild from "esbuild";
-import { copyFile, readFile, writeFile, rm } from "fs/promises";
+import { copyFile, readFile, writeFile, rm } from "node:fs/promises";
 import { glob } from "glob";
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,8 +13,8 @@ import type {
   RequestParameters,
   ReturnTypeOf,
   UnionToIntersection,
-} from "./types";
-import { VERSION } from "./version";
+} from "./types.js";
+import { VERSION } from "./version.js";
 
 const noop = () => {};
 const consoleWarn = console.warn.bind(console);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import * as OctokitTypes from "@octokit/types";
 import { RequestError } from "@octokit/request-error";
 
-import { Octokit } from ".";
+import type { Octokit } from "./index.js";
 
 export type RequestParameters = OctokitTypes.RequestParameters;
 

--- a/test/agent-ca/agent-ca-test.test.ts
+++ b/test/agent-ca/agent-ca-test.test.ts
@@ -1,9 +1,9 @@
-import { createServer, type Server } from "https";
-import { readFileSync } from "fs";
-import { resolve } from "path";
+import { createServer, type Server } from "node:https";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { fetch as undiciFetch, Agent } from "undici";
 import { request } from "@octokit/request";
-import { type AddressInfo } from "net";
+import { type AddressInfo } from "node:net";
 
 const ca = readFileSync(resolve(__dirname, "./ca.crt"));
 

--- a/test/agent-proxy/agent-proxy-test.test.ts
+++ b/test/agent-proxy/agent-proxy-test.test.ts
@@ -9,8 +9,8 @@
  * https://github.com/nodejs/undici/blob/512cdadc403874571cd5035a6c41debab1165310/test/proxy-agent.js#L370-L418
  * Released under the MIT license
  */
-import { Server, createServer } from "http";
-import { type AddressInfo } from "net";
+import { Server, createServer } from "node:http";
+import { type AddressInfo } from "node:net";
 import { ProxyServer, createProxy } from "proxy";
 import { ProxyAgent, fetch as undiciFetch } from "undici";
 import { Octokit } from "../../src";

--- a/test/agent-proxy/agent-proxy-test.test.ts
+++ b/test/agent-proxy/agent-proxy-test.test.ts
@@ -13,7 +13,7 @@ import { Server, createServer } from "node:http";
 import { type AddressInfo } from "node:net";
 import { ProxyServer, createProxy } from "proxy";
 import { ProxyAgent, fetch as undiciFetch } from "undici";
-import { Octokit } from "../../src";
+import { Octokit } from "../../src/index.ts";
 
 describe("client proxy", () => {
   let server: Server;

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -5,7 +5,7 @@ import { createActionAuth } from "@octokit/auth-action";
 import { createOAuthAppAuth } from "@octokit/auth-oauth-app";
 import { install as installFakeTimers, type Clock } from "@sinonjs/fake-timers";
 
-import { Octokit } from "../src";
+import { Octokit } from "../src/index.ts";
 
 const userAgent = `octokit-core.js/0.0.0-development ${getUserAgent()}`;
 

--- a/test/constructor.test.ts
+++ b/test/constructor.test.ts
@@ -1,4 +1,4 @@
-import { Octokit } from "../src";
+import { Octokit } from "../src/index.ts";
 import fetchMock from "fetch-mock";
 
 describe("Smoke test", () => {

--- a/test/defaults.test.ts
+++ b/test/defaults.test.ts
@@ -2,7 +2,7 @@ import fetchMock from "fetch-mock";
 import { getUserAgent } from "universal-user-agent";
 import { createActionAuth } from "@octokit/auth-action";
 
-import { Octokit } from "../src";
+import { Octokit } from "../src/index.ts";
 
 const userAgent = `octokit-core.js/0.0.0-development ${getUserAgent()}`;
 

--- a/test/graphql.test.ts
+++ b/test/graphql.test.ts
@@ -1,6 +1,6 @@
 import fetchMock from "fetch-mock";
 
-import { Octokit } from "../src";
+import { Octokit } from "../src/index.ts";
 
 describe("octokit.graphql()", () => {
   it("is a function", () => {

--- a/test/hook.test.ts
+++ b/test/hook.test.ts
@@ -1,7 +1,7 @@
 import { getUserAgent } from "universal-user-agent";
 import fetchMock from "fetch-mock";
 
-import { Octokit } from "../src";
+import { Octokit } from "../src/index.ts";
 
 const userAgent = `octokit-core.js/0.0.0-development ${getUserAgent()}`;
 

--- a/test/issues.test.ts
+++ b/test/issues.test.ts
@@ -1,4 +1,4 @@
-import { Octokit } from "../src";
+import { Octokit } from "../src/index.ts";
 import fetchMock from "fetch-mock";
 
 /*

--- a/test/log.test.ts
+++ b/test/log.test.ts
@@ -14,7 +14,7 @@ describe("octokit.log", () => {
     const error = jest
       .spyOn(console, "error")
       .mockImplementation(() => calls.push("error"));
-    const Octokit = (await import("../src")).Octokit;
+    const Octokit = (await import("../src/index.ts")).Octokit;
 
     const octokit = new Octokit();
 
@@ -39,7 +39,7 @@ describe("octokit.log", () => {
   });
 
   it("has .debug(), .info(), .warn(), and .error() functions", async () => {
-    const Octokit = (await import("../src")).Octokit;
+    const Octokit = (await import("../src/index.ts")).Octokit;
 
     const octokit = new Octokit();
     expect(typeof octokit.log.debug).toBe("function");
@@ -49,7 +49,7 @@ describe("octokit.log", () => {
   });
 
   it("all .log.*() methods can be overwritten", async () => {
-    const Octokit = (await import("../src")).Octokit;
+    const Octokit = (await import("../src/index.ts")).Octokit;
     const calls: String[] = [];
 
     const octokit = new Octokit({

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -1,4 +1,4 @@
-import { Octokit } from "../src";
+import { Octokit } from "../src/index.ts";
 
 const pluginFoo = () => {
   return { foo: "bar" };

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -1,7 +1,7 @@
 import { getUserAgent } from "universal-user-agent";
 import fetchMock from "fetch-mock";
 
-import { Octokit } from "../src";
+import { Octokit } from "../src/index.ts";
 
 const userAgent = `octokit-core.js/0.0.0-development ${getUserAgent()}`;
 

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -1,4 +1,4 @@
-import { Octokit } from "../src";
+import { Octokit } from "../src/index.ts";
 
 describe("Smoke test", () => {
   it("is a function", () => {

--- a/test/tsconfig.test.json
+++ b/test/tsconfig.test.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "emitDeclarationOnly": false,
     "noEmit": true,
-    "verbatimModuleSyntax": false
+    "verbatimModuleSyntax": false,
+    "allowImportingTsExtensions": true
   },
   "include": ["src/**/*"]
 }

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -2,7 +2,7 @@
 // THIS CODE IS NOT EXECUTED. IT IS JUST FOR TYPECHECKING
 // ************************************************************
 
-import { Octokit } from "../src";
+import { Octokit } from "../src/index.ts";
 
 export function expectType<T>(what: T) {}
 


### PR DESCRIPTION
This PR replaces NodeJS internal module imports with `node:` specifier imports.