### PR TITLE
fix(pkg): add main entry point 

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -55,6 +55,7 @@ async function main() {
       {
         ...pkg,
         files: ["dist-*/**", "bin/**"],
+        main: "./dist-src/index.js",
         exports: {
           ".": {
             types: "./dist-types/index.d.ts",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -56,6 +56,7 @@ async function main() {
         ...pkg,
         files: ["dist-*/**", "bin/**"],
         main: "./dist-src/index.js",
+        types: "./dist-types/index.d.ts",
         exports: {
           ".": {
             types: "./dist-types/index.d.ts",


### PR DESCRIPTION
### Before the change?

Now that the package is ESM, `eslint` may return the following errors:
```
error  Unable to resolve path to module '@octokit/core'  import/no-unresolved
error  "@octokit/core" is not found                      node/no-missing-import
```

### After the change?

eslint should no longer report the errors

### Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

---
