### PR TITLE
fix(pkg): add `default` fallback and `types` export

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ import { Octokit } from "@octokit/core";
 </tbody>
 </table>
 
+As we use [conditional exports](https://nodejs.org/api/packages.html#conditional-exports), you will need to adapt your `tsconfig.json`. See the TypeScript docs on [package.json "exports"](https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports).
+
 ### REST API example
 
 ```js

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -62,6 +62,9 @@ async function main() {
             import: "./dist-src/index.js",
             default: "./dist-src/index.js"
           },
+          "./types": {
+            types: "./dist-types/types.d.ts"
+          }
         },
         sideEffects: false,
       },

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -55,12 +55,12 @@ async function main() {
       {
         ...pkg,
         files: ["dist-*/**", "bin/**"],
-        main: "./dist-src/index.js",
         types: "./dist-types/index.d.ts",
         exports: {
           ".": {
             types: "./dist-types/index.d.ts",
             import: "./dist-src/index.js",
+            default: "./dist-src/index.js"
           },
         },
         sideEffects: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { getUserAgent } from "universal-user-agent";
 import type { HookCollection } from "before-after-hook";
 import Hook from "before-after-hook";
 import { request } from "@octokit/request";
-import { graphql, withCustomRequest } from "@octokit/graphql";
+import { type graphql, withCustomRequest } from "@octokit/graphql";
 import { createTokenAuth } from "@octokit/auth-token";
 
 import type {


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->

Resolves #667 
Resolves #665
Partly reverts #662

---

### Before the change?

<!-- Please describe the current behavior that you are modifying. -->

- Some consumers of this package could not resolve it properly (ex: `jest`, `ts-node`, `tsx`)
- CJS consumers would be getting errors even though the package is ESM
- Consumers cannot import paths from the package like in CJS

### After the change?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Clients should be able to import the module without any errors with the fallback
- CJS consumers will generate a better error with the new fallback
- Consumers are able to import types from the `dist-types/types.d.ts` file in the package


### Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

---
